### PR TITLE
Reuse PATH variable in --path output

### DIFF
--- a/pidgin-windev.sh
+++ b/pidgin-windev.sh
@@ -138,11 +138,11 @@ install() {
 
 # Path configuration
 if [[ -n "$path" ]]; then
-    printf "export PATH='"
-    printf "${win32}/${mingw}/bin:"
-    printf "${win32}/${perl_dir}/perl/bin:"
-    printf "${win32}/${nsis}:"
-    printf "${PATH}'"
+    printf "export PATH=\""
+    printf "%q" "${win32}/${mingw}/bin:"
+    printf "%q" "${win32}/${perl_dir}/perl/bin:"
+    printf "%q" "${win32}/${nsis}:"
+    printf "\${PATH}\"\n"
     exit
 fi
 


### PR DESCRIPTION
With that change using `--path` gives something like

```
export PATH="/cygdrive/c/Users/me/pidgin/win32-dev/mingw-gcc-4.7.2/bin:/cygdrive/c/Users/me/pidgin/win32-dev/strawberry-perl-5.20.1/perl/bin:/cygdrive/c/Users/me/pidgin/win32-dev/nsis-2.46:${PATH}"
```
I don't know if you like that, but for me it is better to see what actually changes. `printf "%q" "..."` takes care of the escaping.

Also I have this habbit of putting `environment` files in my project directories. In that case, changes I do to `PATH` later will also be inherited.